### PR TITLE
Add hiddenlizard.org

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -1,8 +1,8 @@
 bashtel.ru
+hiddenlizard.org
 jabber.cd
 jabber.sampo.ru
 otr.chat
 paranoid.scarab.name
 rassnet.org
 safetyjabber.com
-hiddenlizard.org

--- a/blacklist.txt
+++ b/blacklist.txt
@@ -5,3 +5,4 @@ otr.chat
 paranoid.scarab.name
 rassnet.org
 safetyjabber.com
+hiddenlizard.org


### PR DESCRIPTION
hiddelizard.org sent spam to my server.
They don't provide an 0157 contact, don't have a website
and the hosters abuse address is not accepting emails
(see the following quote).
As it is impossible to contact the operators or hoster I
suggest to stop federating with this server.

```
<abuse@sinersio.com>:
173.194.76.27 failed after I sent the message.
Remote host said: 550-5.7.1 [95.143.172.208      12] Our system has detected that this message is
550-5.7.1 likely unsolicited mail. To reduce the amount of spam sent to Gmail,
550-5.7.1 this message has been blocked. Please visit
550-5.7.1  https://support.google.com/mail/?p=UnsolicitedMessageError
550 5.7.1  for more information. i3si16044058wmb.191 - gsmtp
```