### PR TITLE
Add sj.ms to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -9,4 +9,5 @@ otr.chat
 paranoid.scarab.name
 rassnet.org
 safetyjabber.com
+sj.ms
 xmpp.bytesund.biz


### PR DESCRIPTION
No XEP-0157 contact, captcha on web form broken, emails to support@sj.ms an postmaster@sj.ms bounced (unknown user)

2020-01-30 - sent abuse to abuse@solarcom.ch
2020-02-17 - no reply but ongoing spam
2020-02-17 - adding server to blacklist