### PR TITLE
Add default.rs

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -1,5 +1,6 @@
 bashtel.ru
 darkengine.biz
+default.rs
 hiddenlizard.org
 jabber.cd
 jabber.freenet.de


### PR DESCRIPTION
2020-10-09 Received spam
No 0157 contact
No contact in `whois default.rs`
No website to find a contact

As it seems there is no way to get in touch with the server operator
I suggest adding them to the blacklist instantly. If they want to be 
removed they'll have to provide 0157 and we will be able to inform
them of future spam.