### PR TITLE
Add labas.biz

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -6,6 +6,7 @@ jabber.freenet.de
 jabber.ipredator.se
 jabber.npw.net
 jabber.sampo.ru
+labas.biz
 otr.chat
 paranoid.scarab.name
 rassnet.org


### PR DESCRIPTION
2020-10-11: Spam received; no 0157 contact, no website to find another contact address → sent complaint to mailto:abuse@publicdomainregistry.com
2020-10-15: After several emails trying to explain the difference between XMPP and email to publicdomainregistry they still do not understand it and refuse to contact the operater or take any other action. Issue closed by them.