### PR TITLE
Add onionmessenger.com to the blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -9,6 +9,7 @@ jabber.ipredator.se
 jabber.npw.net
 jabber.sampo.ru
 labas.biz
+onionmessenger.com
 otr.chat
 paranoid.scarab.name
 rassnet.org


### PR DESCRIPTION
They do not publish contact information on XMPP or on the web (only known website is a direct converse installation).

I have tried to contact them through their ISP for pedo content almost two months ago and never got an answer back. I believe it is safe to assume that an inquiry regarding spammers (which are present on this service and I saw not later than today) will be met with the same silence.

### Request to add a new entry

#### Domain to be added

``onionmessenger.com``

#### Checklist

- [x] I contacted the service operator and waited 7 days for an appropriate reaction.

  - [x] No contact information published
  - [ ] No reaction
  - [ ] The situation did not improve

- [x] I contacted the abuse department of the hosting ISP and waited 14 days for an appropriate reaction.

  - [x] No reaction
  - [ ] The situation did not improve

- [x] **I put all this information in the commit message**

#### Documentation

- Date of contact with service operator: None
- Date of contact wtih the hosting ISP: 2020-12-10
