### PR TITLE
Add xmpp.jp.

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -16,3 +16,4 @@ rassnet.org
 safetyjabber.com
 sj.ms
 xmpp.bytesund.biz
+xmpp.jp


### PR DESCRIPTION
### Request to add a new entry

#### Domain to be added

``xmpp.jp``

#### Checklist

- [ ] I contacted the service operator and waited 7 days for an appropriate reaction.

  - [x] No contact information published
  - [ ] No reaction
  - [x] The situation did not improve

- [ ] I contacted the abuse department of the hosting ISP and waited 14 days for an appropriate reaction.

  - [ ] No reaction
  - [x] The situation did not improve

- [x] **I put all this information in the commit message**

#### Documentation

- Date of contact with service operator: 
2024-09-15: Email to support@xmpp.jp bounced: 

```
<support@xmpp.jp>: host mx1.xmpp.jp[153.126.181.71] said: 554 5.7.1
    <support@xmpp.jp>: Recipient address rejected: Access denied (in reply to
    RCPT TO command)
```

Contact form on the website didn't work as well (send button doesn't function).

- Date of contact wtih the hosting ISP:

I did not find any abuse address in whois.


As it is impossible to reach the operator or the hoster I don't see any need to wait and think this server should go straight to the blocklist until there is a way to reach them.
